### PR TITLE
Add support for dropping tables

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -530,6 +530,10 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
 
     public void invalidate(boolean expectMBean)
     {
+        if(engine != null) {
+            engine.invalidate(this);
+        }
+
         // disable and cancel in-progress compactions before invalidating
         valid = false;
 

--- a/src/java/org/apache/cassandra/engine/StorageEngine.java
+++ b/src/java/org/apache/cassandra/engine/StorageEngine.java
@@ -50,6 +50,8 @@ public interface StorageEngine
 
     void close(final ColumnFamilyStore cfs);
 
+    void invalidate(final ColumnFamilyStore cfs);
+
     void setCompactionThroughputMbPerSec(int throughputMbPerSec);
 
     void forceMajorCompaction(ColumnFamilyStore cfs);

--- a/src/java/org/apache/cassandra/rocksdb/RocksDBCF.java
+++ b/src/java/org/apache/cassandra/rocksdb/RocksDBCF.java
@@ -52,6 +52,7 @@ import org.apache.cassandra.rocksdb.streaming.RocksDBStreamWriter;
 import org.apache.cassandra.rocksdb.tools.SanityCheckUtils;
 import org.apache.cassandra.rocksdb.tools.StreamingConsistencyCheckUtils;
 import org.apache.cassandra.streaming.StreamSession;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.Hex;
@@ -106,7 +107,8 @@ public class RocksDBCF implements RocksDBCFMBean
         partitioner = cfs.getPartitioner();
         engine = (RocksDBEngine) cfs.engine;
 
-        rocksDBTableDir = ROCKSDB_DIR + "/" + cfs.keyspace.getName() + "/" + cfs.name;
+        rocksDBTableDir = String.format("%s/%s/%s-%s",
+                ROCKSDB_DIR, cfs.keyspace.getName(), cfs.name, ByteBufferUtil.bytesToHex(ByteBufferUtil.bytes(cfId)));
         FileUtils.createDirectory(ROCKSDB_DIR);
         FileUtils.createDirectory(rocksDBTableDir);
 

--- a/src/java/org/apache/cassandra/rocksdb/RocksDBCF.java
+++ b/src/java/org/apache/cassandra/rocksdb/RocksDBCF.java
@@ -82,7 +82,7 @@ import static org.apache.cassandra.rocksdb.RocksDBConfigs.ROCKSDB_DIR;
 public class RocksDBCF implements RocksDBCFMBean
 {
     private static final Logger logger = LoggerFactory.getLogger(RocksDBCF.class);
-    private final UUID cfID;
+    private final UUID cfId;
     private final ColumnFamilyStore cfs;
     private final IPartitioner partitioner;
     private final RocksDBEngine engine;
@@ -100,7 +100,7 @@ public class RocksDBCF implements RocksDBCFMBean
     public RocksDBCF(ColumnFamilyStore cfs) throws RocksDBException
     {
         this.cfs = cfs;
-        cfID = cfs.metadata.cfId;
+        cfId = cfs.metadata.cfId;
         partitioner = cfs.getPartitioner();
         engine = (RocksDBEngine) cfs.engine;
 
@@ -298,7 +298,7 @@ public class RocksDBCF implements RocksDBCFMBean
             rocksDB.close();
 
             // remove the rocksdb instance, since it's not usable
-            engine.rocksDBFamily.remove(cfID);
+            engine.rocksDBFamily.remove(cfId);
         }
     }
 
@@ -337,9 +337,9 @@ public class RocksDBCF implements RocksDBCFMBean
         return sb.toString();
     }
 
-    public UUID getCfID()
+    public UUID getCfId()
     {
-        return cfID;
+        return cfId;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/rocksdb/RocksDBEngine.java
+++ b/src/java/org/apache/cassandra/rocksdb/RocksDBEngine.java
@@ -142,9 +142,20 @@ public class RocksDBEngine implements StorageEngine
                 rocksDBCF.truncate();
             else
                 logger.info("Can not find rocksdb table: " + cfs.name);
-        }
+
         catch (RocksDBException e)
         {
+            logger.error(e.toString(), e);
+        }
+    }
+
+    public void invalidate(ColumnFamilyStore cfs) {
+        try {
+            RocksDBCF rocksDBCF = getRocksDBCF(cfs);
+            rocksDBCF.close();
+            rocksDBCF.destroy();
+        }
+        catch(RocksDBException e) {
             logger.error(e.toString(), e);
         }
     }

--- a/src/java/org/apache/cassandra/rocksdb/streaming/RocksDBStreamWriter.java
+++ b/src/java/org/apache/cassandra/rocksdb/streaming/RocksDBStreamWriter.java
@@ -148,6 +148,6 @@ public class RocksDBStreamWriter
 
     private void updateProgress(boolean completed)
     {
-        RocksDBStreamUtils.rocksDBProgress(session, rocksDBCF.getCfID().toString(), ProgressInfo.Direction.OUT, outgoingBytes, streamedPairs, estimatedTotalKeys, completed);
+        RocksDBStreamUtils.rocksDBProgress(session, rocksDBCF.getCfId().toString(), ProgressInfo.Direction.OUT, outgoingBytes, streamedPairs, estimatedTotalKeys, completed);
     }
 }


### PR DESCRIPTION
This branch enables support for dropping tables. In addition do that, it:
 * changes the capitalization of cfId to match the rest of the Cassandra codebase
 * namespaces tables on-disk by cfId, so that tables which are dropped and re-created with the same name have different on-disk locations.